### PR TITLE
Implement get tile map API

### DIFF
--- a/server/cmd/config.go
+++ b/server/cmd/config.go
@@ -39,6 +39,7 @@ type S3ClientConfig struct {
 
 type CryptoConfig struct {
 	JWTSecret string `mapstructure:"jwt_secret"`
+	SimpleKey string `mapstructure:"simple_key"`
 }
 
 func loadConfig() Config {

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -50,8 +50,10 @@ func main() {
 
 	mux := http.NewServeMux()
 
+	simpleKeyMW := middleware.NewSimpleKey(config.Crypto.SimpleKey)
+
 	users.RegisterServer(mux, pool, querier, wt)
-	tiles.RegisterServer(mux, pool, querier, s3Client, publisherClient)
+	tiles.RegisterServer(mux, pool, querier, s3Client, publisherClient, simpleKeyMW)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins:   config.HTTPServer.AllowedOrigins,

--- a/server/examples/requests/tiles.http
+++ b/server/examples/requests/tiles.http
@@ -45,3 +45,8 @@ Authorization: Bearer {{token}}
   "subtitle": "The best pipes in town",
   "link": "https://pipes.com"
 }
+
+### Get the tile map at a coordination
+GET {{host}}/tiles/map/0/256
+Accept: application/octet-stream
+Authorization: Bearer {{simple_key}}

--- a/server/internal/middleware/factory.go
+++ b/server/internal/middleware/factory.go
@@ -1,0 +1,7 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+type Middleware func(http.HandlerFunc) http.HandlerFunc

--- a/server/internal/middleware/simplekey.go
+++ b/server/internal/middleware/simplekey.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+func NewSimpleKey(simpleKey string) Middleware {
+	key := strings.TrimSpace(simpleKey)
+	if key == "" {
+		panic("simpleKey cannot be empty")
+	}
+
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			rawAuthHeader := r.Header.Get("Authorization")
+			if rawAuthHeader == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			matches := authHeaderRegexp.FindStringSubmatch(rawAuthHeader)
+
+			if len(matches) != 2 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			if matches[1] != key {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			next(w, r)
+		}
+	}
+}

--- a/server/internal/storage/querier.go
+++ b/server/internal/storage/querier.go
@@ -13,6 +13,7 @@ type Querier interface {
 	CreateUser(ctx context.Context, db DBTX, email string, password string) (User, error)
 	EditTileByOwner(ctx context.Context, db DBTX, arg EditTileByOwnerParams) (Tile, error)
 	GetTile(ctx context.Context, db DBTX, x int32, y int32) (Tile, error)
+	GetTileAvailabilityMap(ctx context.Context, db DBTX, x int32, y int32, xx int32, yy int32) ([]GetTileAvailabilityMapRow, error)
 	GetUser(ctx context.Context, db DBTX, email string) (User, error)
 	SpendCoins(ctx context.Context, db DBTX, coins int32, email string) (User, error)
 }

--- a/server/internal/storage/tiles.sql
+++ b/server/internal/storage/tiles.sql
@@ -19,3 +19,11 @@ select *
 from tiles
 where x = @x
   and y = @y;
+
+-- name: GetTileAvailabilityMap :many
+select x, y
+from tiles
+where x >= @x
+  and y >= @y
+  and x < @xx
+  and y < @yy;

--- a/server/internal/storage/tiles.sql.go
+++ b/server/internal/storage/tiles.sql.go
@@ -100,3 +100,42 @@ func (q *Queries) GetTile(ctx context.Context, db DBTX, x int32, y int32) (Tile,
 	)
 	return i, err
 }
+
+const getTileAvailabilityMap = `-- name: GetTileAvailabilityMap :many
+select x, y
+from tiles
+where x >= $1
+  and y >= $2
+  and x < $3
+  and y < $4
+`
+
+type GetTileAvailabilityMapRow struct {
+	X int32 `db:"x" json:"x"`
+	Y int32 `db:"y" json:"y"`
+}
+
+func (q *Queries) GetTileAvailabilityMap(ctx context.Context, db DBTX, x int32, y int32, xx int32, yy int32) ([]GetTileAvailabilityMapRow, error) {
+	rows, err := db.Query(ctx, getTileAvailabilityMap,
+		x,
+		y,
+		xx,
+		yy,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetTileAvailabilityMapRow{}
+	for rows.Next() {
+		var i GetTileAvailabilityMapRow
+		if err := rows.Scan(&i.X, &i.Y); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/server/internal/tiles/getmap.go
+++ b/server/internal/tiles/getmap.go
@@ -1,0 +1,45 @@
+package tiles
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+)
+
+const (
+	MapChunkSize = 256
+)
+
+func (s *server) GetMapHandler(w http.ResponseWriter, r *http.Request) {
+	xRaw := r.PathValue("x")
+	yRaw := r.PathValue("y")
+
+	x, errX := strconv.ParseInt(xRaw, 10, 32)
+	y, errY := strconv.ParseInt(yRaw, 10, 32)
+	if errX != nil || errY != nil {
+		http.Error(w, "invalid coordinates", http.StatusBadRequest)
+	}
+
+	ctx := r.Context()
+
+	if x%MapChunkSize != 0 || y%MapChunkSize != 0 {
+		http.Error(w, "invalid coordinates", http.StatusBadRequest)
+		return
+	}
+
+	tiles, err := s.querier.GetTileAvailabilityMap(ctx, s.pool, int32(x), int32(y), int32(x+MapChunkSize), int32(y+MapChunkSize))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	m := make([]byte, MapChunkSize*MapChunkSize)
+	for _, t := range tiles {
+		index := t.Y*MapChunkSize + t.X
+		m[index] = byte(rand.Intn(255) + 1)
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	w.Write(m)
+}

--- a/server/internal/tiles/routes.go
+++ b/server/internal/tiles/routes.go
@@ -24,6 +24,7 @@ func RegisterServer(
 	querier storage.Querier,
 	s3Client s3bucket.S3Bucket,
 	publisherClient publisher.Publisher,
+	simpleKeyMW middleware.Middleware,
 ) {
 	s := &server{
 		pool:            pool,
@@ -36,4 +37,5 @@ func RegisterServer(
 	mux.HandleFunc("POST /tiles/{x}/{y}", middleware.WithAuthorization(s.PurchaseHandler))
 	mux.HandleFunc("PUT /tiles/{x}/{y}", middleware.WithAuthorization(s.EditHandler))
 	mux.HandleFunc("POST /tiles/{x}/{y}/images", middleware.WithAuthorization(s.CreateImageHandler))
+	mux.HandleFunc("GET /tiles/map/{x}/{y}", simpleKeyMW(s.GetMapHandler))
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to enhance the server's functionality, including a new middleware for simple key authentication, a new endpoint for retrieving tile maps, and database query enhancements.

### Middleware and Authentication:

* Added a new `SimpleKey` middleware for simple key-based authentication. (`server/internal/middleware/simplekey.go`)
* Integrated the `SimpleKey` middleware into the server's main function and routes. (`server/cmd/server.go`, `server/internal/tiles/routes.go`) [[1]](diffhunk://#diff-98e98303a4ff8c619a206b46b10f3b97ce79ae30f8feb276ebd5744ef4536824R53-R56) [[2]](diffhunk://#diff-50b4056850274ed92a3f6e7c904f68f7cd09d3da83ebd8360fd6f43b600eefdcR40)

### New Endpoint:

* Implemented a new endpoint to get the tile map at specified coordinates. (`server/internal/tiles/getmap.go`, `server/examples/requests/tiles.http`) [[1]](diffhunk://#diff-687651f3f9d143aba98eb305abacd3bdf4e1396290b13f5259474ec50831fc1eR1-R45) [[2]](diffhunk://#diff-b6d15bddc87c447245893c2f704fa977eda9910cbca7d47c32f2b887da1acedfR48-R52)

### Database Enhancements:

* Added a new method `GetTileAvailabilityMap` to the `Querier` interface for fetching tile availability. (`server/internal/storage/querier.go`, `server/internal/storage/tiles.sql`, `server/internal/storage/tiles.sql.go`) [[1]](diffhunk://#diff-d293b730acff921a0375110a37bf1edba9be5102b8b1caf4272cd570855b1fefR16) [[2]](diffhunk://#diff-2f224df5ad97e83c45a92005f5273ee562578d2fb7f1e62949176ae2611e5f49R22-R29) [[3]](diffhunk://#diff-27931dcf4e5bf22943d705d3fbcceff33125a395053e2007e01fa687629f54efR103-R141)

### Configuration Updates:

* Introduced a new `SimpleKey` configuration option in the `CryptoConfig` struct. (`server/cmd/config.go`)