### PR TITLE
Downgrade runner ubuntu version to match libc requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform:
           - name: linux
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - name: macos
             runner: macos-latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change updates the runner version for the Linux platform from `ubuntu-24.04` to `ubuntu-22.04`.