### PR TITLE
Include source in publisher request body

### DIFF
--- a/server/internal/clients/publisher/publisher.go
+++ b/server/internal/clients/publisher/publisher.go
@@ -26,6 +26,7 @@ type Config struct {
 }
 
 type PublishRequest struct {
+	Source   string `json:"source"`
 	Title    string `json:"title"`
 	Subtitle string `json:"subtitle"`
 	Link     string `json:"link"`
@@ -65,6 +66,7 @@ func (p *publisher) Publish(ctx context.Context, x, y int32) error {
 	}
 
 	body := PublishRequest{
+		Source:   fmt.Sprintf("%d-%d", x, y),
 		Title:    tile.Title,
 		Subtitle: tile.Subtitle,
 		Link:     tile.Link,


### PR DESCRIPTION
This pull request includes changes to the `server/internal/clients/publisher/publisher.go` file, adding a new field to the `PublishRequest` struct and updating the `Publish` method to include this new field.

Changes to `publisher.go`:

* Added a `Source` field to the `PublishRequest` struct to capture the source information.
* Updated the `Publish` method to populate the new `Source` field using the provided `x` and `y` parameters.