### PR TITLE
[Fix] Fix trailing slash problem with signup api

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Default host URL
-DEFAULT_HOST="http://localhost:8000"
+DEFAULT_HOST="https://baldosa-api.ehsandar.top"
 
 # Parse command-line options
 while getopts ":h:" opt; do
@@ -35,7 +35,7 @@ create_account() {
     read -sp "Password: " password
     echo
 
-    response=$(curl -s -L -w "%{http_code}" -o temp_response.txt -X POST "$HOST/users" \
+    response=$(curl -s -L -w "%{http_code}" -o temp_response.txt -X POST "$HOST/users/" \
         -H "Content-Type: application/json" \
         -d "{\"email\": \"$email\", \"password\": \"$password\"}")
 


### PR DESCRIPTION
This pull request includes updates to the `cli.sh` script to change the default host URL and correct the endpoint URL in the `create_account` function.

* Updated the default host URL to use a secure HTTPS connection and point to the new API endpoint. (`cli.sh`)
* Corrected the endpoint URL in the `create_account` function to include a trailing slash for consistency. (`cli.sh`)